### PR TITLE
Fix code typo & update README (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Last login: Thu Nov 19 10:35:42 2020
 ~$
 ```
 
+## Kernel Module Signing
+
+An example for kernel module signing [can be found here](kernel_signing.md).
+
 # Configuration
 
 AWS credentials are pulled from the usual places (environment variables, ~/.aws/credentials, and IMDS). Further configuration is read from either `/etc/aws-kms-pkcs11/config.json` or `$XDG_CONFIG_HOME/aws-kms-pkcs11/config.json` (note that `XDG_CONFIG_HOME=$HOME/.config` by default).
@@ -128,7 +132,7 @@ The `slots` key is the only supported top-level attribute at the moment. This is
 | kms\_key\_id | Y | dbafb7de-106e-4277-97fe-a7f5635516a5 | The key id to use for this slot. |
 | label | N | my-signing-key | The token label to use for this slot; this is usually used when using a PKCS#11 URI. If not specified, the first 32 characters of the KMS key ID will be used as a label. |
 | aws\_region | N | us-west-2 | The AWS region where the above key resides. Uses the AWS default if not specified. |
-| certificate | N | MIIBMjCB2... | A base64-encoded DER-encoded X.509 certificate to make available as an object on this slot. This is useful for use-cases where a signing library expects both a certificate and key available on the PKCS#11 token. You can generate a certificate with this format with a command such as `openssl x509 -in mycert.pem -outform der | openssl base64 -A` |
+| certificate | N | MIIBMjCB2... | A base64-encoded DER-encoded X.509 certificate to make available as an object on this slot. This is useful for use-cases where a signing library expects both a certificate and key available on the PKCS#11 token. You can generate a certificate with this format with a command such as `openssl x509 -in mycert.pem -outform der \| openssl base64 -A` |
 | certificate_path | N | /etc/aws-kms-pkcs11/mycert.pem | Same as "certificate" but refers to a PEM certificate on disk instead of embedding the certificate value into the config. |
 
 If you are encountering errors using this provider, try setting the `AWS_KMS_PKCS11_DEBUG` environment variable to a non-empty value. This should enable debug logging to stdout from the module.

--- a/aws_kms_pkcs11.cpp
+++ b/aws_kms_pkcs11.cpp
@@ -146,7 +146,7 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
                     kms_key_id = string(json_object_get_string(val));
                 }
                 if (json_object_object_get_ex(slot_item, "aws_region", &val) && json_object_is_type(val, json_type_string)) {
-                    kms_key_id = string(json_object_get_string(val));
+                    aws_region = string(json_object_get_string(val));
                 }
                 if (json_object_object_get_ex(slot_item, "certificate", &val) && json_object_is_type(val, json_type_string)) {
                     debug("Parsing certificate for slot: %s", label.c_str());

--- a/kernel_signing.md
+++ b/kernel_signing.md
@@ -1,0 +1,50 @@
+Kernel Signing using AWS KMS
+==============================
+
+When building a custom kernel it may be useful to sign the modules to prevent unauthorized module loading on the system. This is most appropriate for embedded devices. The process is pretty straightforward.
+
+At first we need to do a fake build to get a x509.genkey file which we can use for generating the certificate. A sample is included, but it's better to use the same one the kernel would use. The kernel will automatically generate this file and create a certificate if CONFIG_MODULE_SIG_KEY="", so we take advantage of this to get a sample x509.genkey file.
+
+Add the following to the kernel config:
+```
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_SHA256=y
+CONFIG_MODULE_SIG_KEY=""
+```
+Then build the kernel using `make` and the x509.genkey file should be located in `<kernel_source>/certs/x509.genkey`. You will use this file to self-sign a certificate in the following step.
+
+If you want to skip the above step and use a passed file here is a sample. Some extra fields have been added (such as Organisation Name) to provide extra information in the certificate.
+```
+[ req ]
+default_bits = 2048
+distinguished_name = req_distinguished_name
+prompt = no
+string_mask = utf8only
+x509_extensions = myexts
+
+[ req_distinguished_name ]
+countryName            = US
+stateOrProvinceName    = Your State
+localityName           = Your City
+organizationName       = Your Company
+commonName             = Kernel Signing Key
+emailAddress           = you@example.com
+
+[ myexts ]
+basicConstraints=critical,CA:FALSE
+keyUsage=digitalSignature
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid
+```
+
+Make sure your aws-kms-pkcs11 json config is setup to point to the key, then sign your certificate with the following 
+ `AWS_KMS_PKCS11_DEBUG=1 PKCS11_MODULE_PATH="/usr/lib/x86_64-linux-gnu/pkcs11/aws_kms_pkcs11.so" openssl req -config <(cat "<kernel_source>/certs/x509.genkey") -x509 -key "pkcs11:token=<your_key_label>" -keyform engine -engine pkcs11 -out mycert.pem -days 36500`. 
+ 
+Now you have a signed certificate with "mycert.pem", add this as a certificate in your aws kms config, update with this line (more details in config section below): `"certificate_path": "mykey.crt"`.
+
+Update your kernel config:
+`CONFIG_MODULE_SIG_KEY="pkcs11:token=<your_key_label>`
+
+Now make the kernel as normal and modules will be signed using the kms private key and your public certificate you just signed above.
+
+Make sure to keep the self signed certificate in a safe place.


### PR DESCRIPTION
* Update aws_kms_pkcs11.cpp

Fixed bug with kms_key_id pointing to aws_region

* Update README.md

Fixed formatting to escape pipe char in Markdown table

* Create kernel_signing.md

Instructions ar e bit longer so added to a new file.

* Update README.md

Added kernel module signing instructions to README